### PR TITLE
refactor(package): remove unnecessary fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,5 @@
 {
     "name": "zdearo/laravel-auto-translate",
-    "version": "dev-main",
-    "type": "library",
     "description": "A Laravel package for auto translate strings.",
     "keywords": [
         "Adryel Dearo",
@@ -41,12 +39,6 @@
             "Zdearo\\LaravelAutoTranslate\\Tests\\": "tests/",
             "Workbench\\App\\": "workbench/app/"
         }
-    },
-    "scripts": {
-        "post-autoload-dump": "@composer run prepare",
-        "prepare": "@php vendor/bin/testbench package:discover --ansi",
-        "analyse": "vendor/bin/phpstan analyse",
-        "format": "vendor/bin/pint"
     },
     "config": {
         "sort-packages": true,


### PR DESCRIPTION
This pull request makes adjustments to the `composer.json` file, primarily simplifying the package metadata and removing unnecessary scripts.

Changes to package metadata:

* Removed the `version` and `type` fields from the `composer.json` file, simplifying the metadata for the package.

Changes to scripts:

* Removed the `scripts` section, which previously included commands for post-autoload actions, package discovery, static analysis, and code formatting.